### PR TITLE
Remove self-link on introduction to CSS page

### DIFF
--- a/files/en-us/learn/css/css_layout/introduction/index.html
+++ b/files/en-us/learn/css/css_layout/introduction/index.html
@@ -703,7 +703,7 @@ form p {
 <h2 id="In_this_module">In this module</h2>
 
 <ul>
- <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Introduction">Introduction to CSS layout</a></li>
+ <li>Introduction to CSS layout</li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Normal_Flow">Normal flow</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Flexbox">Flexbox</a></li>
  <li><a href="/en-US/docs/Learn/CSS/CSS_layout/Grids">Grid</a></li>


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)

This fixes the following broken link flaw:

1. /en-US/docs/Learn/CSS/CSS_layout/Introduction 👀 line 710:15
Link points to the page it's already on